### PR TITLE
watchdog: fix "invalid reference format: repository name must be lowercase"

### DIFF
--- a/srcds/Dockerfile
+++ b/srcds/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim as ENTRYPOINT
+FROM debian:bullseye-slim as entrypoint
 
 RUN apt-get update \
 		&& apt-get install -y \
@@ -45,7 +45,7 @@ RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 WORKDIR /srcds
 
 COPY ./srcds/*.sh ./
-COPY --from=ENTRYPOINT main ./
+COPY --from=entrypoint main ./
 
 RUN useradd -m -u $UID srcds && mkdir srv && chown srcds srv && chmod +x *.sh
 

--- a/watchdog/Dockerfile
+++ b/watchdog/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim as NODE
+FROM debian:buster-slim as node
 
 RUN dpkg --add-architecture i386 \
 		&& apt-get update \
@@ -16,7 +16,7 @@ RUN apt-get install -y nodejs --no-install-recommends --no-install-suggests
 
 
 
-FROM NODE AS NODE_MODULES
+FROM node AS node-modules
 
 WORKDIR /INSTALL
 COPY ./watchdog/*.* ./
@@ -24,7 +24,7 @@ RUN npm install --omit=dev
 
 
 
-FROM NODE
+FROM node
 
 ENV SM_VERSION=1.11
 ENV MM_VERSION=1.11
@@ -56,7 +56,7 @@ VOLUME ["/repo"]
 WORKDIR /watchdog
 
 COPY ./watchdog/*.js ./
-COPY --from=NODE_MODULES /INSTALL/node_modules/ ./node_modules/
+COPY --from=node-modules /INSTALL/node_modules/ ./node_modules/
 
 RUN chown -R $UID ./ /steamcmd
 


### PR DESCRIPTION
currently the watchdog image cannot be built using `docker compose` - this PR fixes that

`docker-compose.yaml`:

```yaml
version: "3.6"

services:
  watchdog:
    build:
      context: https://github.com/kinsi55/docker_SRCDockS.git#master
      dockerfile: watchdog/Dockerfile
      args:
        UID: 2000
```

error:

    failed to solve: failed to parse stage name "NODE": invalid reference format: repository name must be lowercase