### PR TITLE
Add server auto update configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The entire server structure is rebuilt on every restart, so any files actively w
 7. `STOCK_SM_PLUGINS` (Irrelevant to CS2) - If not empty (Default) will delete all but the specified default plugins that ship with SourceMod. If you want to keep Basebans and Basecommands you would specify `basebans,basecommands`. If you want to delete all plugins just specify any non-empty value thats not the name of a default plugin.
 8. `VERSION_PIN` - Can be used to pin the Server to a specific version rather than using the latest version (Full folder name, ex v_13337)
 9. `FAKELATEST` - When set / not empty, the server will use the `steam.inf` file from the latest version, no matter what version the server files are actually from. Game Updates often are non-breaking to the network protocol but can be breaking to plugins, this can be used as a stopgap in case of breaking updates to get the server back up until patches are available for the parts that broke.
+10. `AUTOUPDATE` - When unset or 1, defaults to server auto updating. When set to 0, server will NOT automatically update.
 
 IP / PORT are also what will be accessed to do the healthcheck. If you need to access a different IP/port for that you can override it with `HEALTH_IP` and `HEALTH_PORT` respectively
 

--- a/srcds/runServer.sh
+++ b/srcds/runServer.sh
@@ -1,14 +1,26 @@
 #!/bin/bash
 
+# AUTOUPDATE=1 (default): includes -autoupdate flag for auto-restart
+# AUTOUPDATE=0: excludes -autoupdate flag
+AUTOUPDATE="${AUTOUPDATE:-1}"
+if [[ "$AUTOUPDATE" != "0" && "$AUTOUPDATE" != "1" ]]; then
+	echo "Warning: AUTOUPDATE must be '0' or '1'. Defaulting to '1'."
+	AUTOUPDATE="1"
+fi
+AUTOP_FLAG=""
+if [[ "$AUTOUPDATE" == "1" ]]; then
+	AUTOP_FLAG="-autoupdate"
+fi
+
 runServerCustom() {
 	export LD_LIBRARY_PATH="/srcds/srv:/srcds/srv/bin"
-	./srcds_linux -game $APP_NAME $SRCDS_ARGS -strictportbind -port ${PORT-27015} -ip ${IP-0.0.0.0} -autoupdate -nobreakpad
+	./srcds_linux -game $APP_NAME $SRCDS_ARGS -strictportbind -port ${PORT-27015} -ip ${IP-0.0.0.0} $AUTOP_FLAG -nobreakpad
 }
 
 runServer() {
 	# The order is IMPORTANT. -autoupdate enables auto-restart,
 	# but -norestart removes it again, keeping autoupdate active but using my autorestart instead
-	/bin/bash srcds_run $SRCDS_ARGS -strictportbind -port ${PORT-27015} -ip ${IP-0.0.0.0} -autoupdate -norestart -nobreakpad
+	/bin/bash srcds_run $SRCDS_ARGS -strictportbind -port ${PORT-27015} -ip ${IP-0.0.0.0} $AUTOP_FLAG -norestart -nobreakpad
 }
 
 cd /srcds/srv


### PR DESCRIPTION
This project was initially founded on CS:GO, and several CS:GO server owners continue to utilize the legacy dedicated server.

This PR introduced a new environment variable to the server - AUTOUPDATE. As it stands, `-autoupdate` is hardcoded inside of srcds/runServer.sh. When spinning up a fresh CS:GO server, the game believes there is an update all of the time, and you are met with:

`Your server is out of date and will be shutdown during hibernation or changelevel, whichever comes first.`

If hibernation is enabled, the server will constantly restart (because there is no update for CS:GO), or restart every changelevel.

This PR adds `AUTOUPDATE` to the server image, to entirely enable or disable the -autoupdate flag. Readme has been updated, also fully tested and working with values of 0, 1, and random strings added as a safety. A console warning has been added if configuration is invalid:

`Warning: AUTOUPDATE must be '0' or '1'. Defaulting to '1'.`